### PR TITLE
feat(encrypter): define params for encryption method

### DIFF
--- a/.github/workflows/release-web-app.yaml
+++ b/.github/workflows/release-web-app.yaml
@@ -5,7 +5,7 @@ on:
     # TODO: after release stable we can build based on github tags
     branches:
       - main
-  workflow_dispatch:  
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,9 +1,0 @@
-compressionLevel: mixed
-
-enableGlobalCache: false
-
-nmHoistingLimits: workspaces
-
-nodeLinker: node-modules
-
-yarnPath: .yarn/releases/yarn-4.6.0.cjs

--- a/package.json
+++ b/package.json
@@ -1,23 +1,24 @@
 {
-  "name": "pactus-wallet",
-  "version": "0.1.0",
-  "repository": "https://github.com/pactus-project/pactus-wallet.git",
-  "dependencies": {
-    "turbo": "^2.4.1",
-    "typescript": "^5.7.3"
-  },
-  "scripts": {
-    "build": "npx turbo build",
-    "build:web": "npx turbo build:web",
-    "build:pkg": "npx turbo build:pkg"
-  },
-  "workspaces": {
-    "packages": [
-      "packages/*",
-      "apps/*",
-      "tests/*"
-    ]
-  },
-  "packageManager": "yarn@4.6.0",
-  "private": true
+    "name": "pactus-wallet",
+    "version": "0.1.0",
+    "repository": "https://github.com/pactus-project/pactus-wallet.git",
+    "license": "MIT",
+    "dependencies": {
+        "turbo": "^2.4.1",
+        "typescript": "^5.7.3"
+    },
+    "scripts": {
+        "build": "npx turbo build",
+        "build:web": "npx turbo build:web",
+        "build:pkg": "npx turbo build:pkg"
+    },
+    "workspaces": {
+        "packages": [
+            "packages/*",
+            "apps/*",
+            "tests/*"
+        ]
+    },
+    "packageManager": "yarn@4.6.0",
+    "private": true
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,5 @@
             "tests/*"
         ]
     },
-    "packageManager": "yarn@4.6.0",
     "private": true
 }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -2,6 +2,7 @@
     "name": "@pactus-wallet/wallet",
     "version": "0.1.0",
     "description": "Pactus wallet manager",
+    "license": "MIT",
     "main": "index.js",
     "scripts": {
         "build": "rm -fr dist && tsc",

--- a/packages/wallet/src/params.ts
+++ b/packages/wallet/src/params.ts
@@ -1,0 +1,40 @@
+export class Params {
+    private data: Map<string, string>;
+
+    constructor() {
+        this.data = new Map<string, string>();
+    }
+
+    setNumber(key: string, val: number): void {
+        this.data.set(key, val.toString());
+    }
+
+    setBytes(key: string, val: Uint8Array): void {
+        const base64 = Buffer.from(val).toString('base64');
+        this.data.set(key, base64);
+    }
+
+    setString(key: string, val: string): void {
+        this.data.set(key, val);
+    }
+
+    getNumber(key: string, defaultValue: number): number {
+        const val = this.data.get(key);
+        if (!val)
+            return defaultValue;
+
+        return parseInt(val, 10);
+    }
+
+    getBytes(key: string): Uint8Array {
+        const val = this.data.get(key);
+        if (val === undefined) throw new Error(`Key "${key}" not found`);
+        return new Uint8Array(Buffer.from(val, 'base64'));
+    }
+
+    getString(key: string): string {
+        const val = this.data.get(key);
+        if (val === undefined) throw new Error(`Key "${key}" not found`);
+        return val;
+    }
+}

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -93,8 +93,7 @@ export class Wallet {
             return new Wallet(core, wallet, password);
         } catch (error) {
             throw new Error(
-                `Failed to restore wallet: ${
-                    error instanceof Error ? error.message : 'Unknown error'
+                `Failed to restore wallet: ${error instanceof Error ? error.message : 'Unknown error'
                 }`
             );
         }

--- a/packages/wallet/test/params.test.ts
+++ b/packages/wallet/test/params.test.ts
@@ -32,6 +32,10 @@ describe('Encrypter Params', () => {
         expect(p.getBytes('k1')).toStrictEqual(new Uint8Array([0, 0]));
         expect(p.getBytes('k2')).toStrictEqual(new Uint8Array([0xFF, 0xFF]));
         expect(p.getBytes('k3')).toStrictEqual(new Uint8Array([]));
+
+        expect(p.getString('k1')).toBe("AAA=");
+        expect(p.getString('k2')).toBe("//8=");
+        expect(p.getString('k3')).toBe("");
     });
 
     it('should handle byte strings', () => {

--- a/packages/wallet/test/params.test.ts
+++ b/packages/wallet/test/params.test.ts
@@ -1,0 +1,45 @@
+import { Params } from '../src/params';
+
+describe('Encrypter Params', () => {
+
+    describe('should handle numbers', () => {
+        const p = new Params();
+
+        p.setNumber('k1', 0);
+        p.setNumber('k2', 0xFF);
+        p.setNumber('k3', 0xFFFFFFFF);
+        p.setNumber('k4', 0xFFFFFFFFFFFFFFFF);
+
+        expect(p.getNumber('k1', 0)).toBe(0);
+        expect(p.getNumber('k2', 0)).toBe(0xFF);
+        expect(p.getNumber('k3', 0)).toBe(0xFFFFFFFF);
+        expect(p.getNumber('k4', 0)).toBe(0xFFFFFFFFFFFFFFFF);
+    });
+
+    it('should return default values for non-existent keys', () => {
+        const p = new Params();
+
+        expect(p.getNumber('not-exist', 24)).toBe(24);
+    });
+
+    it('should handle byte arrays', () => {
+        const p = new Params();
+
+        p.setBytes('k1', new Uint8Array([0, 0]));
+        p.setBytes('k2', new Uint8Array([0xFF, 0xFF]));
+        p.setBytes('k3', new Uint8Array([]));
+
+        expect(p.getBytes('k1')).toStrictEqual(new Uint8Array([0, 0]));
+        expect(p.getBytes('k2')).toStrictEqual(new Uint8Array([0xFF, 0xFF]));
+        expect(p.getBytes('k3')).toStrictEqual(new Uint8Array([]));
+    });
+
+    it('should handle byte strings', () => {
+        const p = new Params();
+
+        p.setString('k4', 'foo');
+        p.setString('k5', 'bar');
+        expect(p.getString('k4')).toBe('foo');
+        expect(p.getString('k5')).toBe('bar');
+    });
+});

--- a/packages/wallet/test/params.test.ts
+++ b/packages/wallet/test/params.test.ts
@@ -37,9 +37,11 @@ describe('Encrypter Params', () => {
     it('should handle byte strings', () => {
         const p = new Params();
 
-        p.setString('k4', 'foo');
-        p.setString('k5', 'bar');
-        expect(p.getString('k4')).toBe('foo');
-        expect(p.getString('k5')).toBe('bar');
+        p.setString('k1', 'foo');
+        p.setString('k2', 'bar');
+        p.setString('k3', '');
+        expect(p.getString('k1')).toBe('foo');
+        expect(p.getString('k2')).toBe('bar');
+        expect(p.getString('k3')).toBe('');
     });
 });


### PR DESCRIPTION
This PR introduces the `Params` class, which defines a set of parameters used for encrypting wallet seeds. 

These parameters are essentially a collection of data that can be stored and retrieved as strings, numbers, or byte arrays. They will be used to store encryption-related information such as iteration count, parallelism, and memory usage.