### PR TITLE
refactor(web): replace pacviewer with pactusscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ The network preference is automatically saved to your browser's local storage an
 - **Mainnet**: Production network for real transactions
   - RPC Endpoints: `bootstrap1-4.pactus.org/jsonrpc`
   - Coin Type: 21888
-  - Block Explorer: [Phoenix Pacviewer](https://phoenix.pacviewer.com)
+  - Block Explorer: [PactusScan](https://pactusscan.com)
 
 - **Testnet**: Development and testing network
   - RPC Endpoints: `testnet1-4.pactus.org/jsonrpc`
   - Coin Type: 21777
-  - Block Explorer: [Phoenix Pacviewer Testnet](https://phoenix.pacviewer.com)
+  - Block Explorer: [PactusScan Testnet](https://phoenix.pactusscan.com)
 
 ### Network Indicators
 

--- a/apps/web/src/components/send/SuccessTransferModal.tsx
+++ b/apps/web/src/components/send/SuccessTransferModal.tsx
@@ -14,7 +14,7 @@ import Typography from '../common/Typography';
 import GradientText from '../common/GradientText';
 import { successIcon, copyIcon } from '../../assets/images/icons';
 import { useWallet } from '@/wallet';
-import { PACVIEWER_URL } from '../../utils/constants';
+import { PACTUSSCAN_URL } from '../../utils/constants';
 
 interface SuccessTransferModalProps {
   isOpen: boolean;
@@ -132,9 +132,9 @@ const SuccessTransferModal: React.FC<SuccessTransferModalProps> = ({
 
   const handleViewOnExplorer = () => {
     if (wallet?.isTestnet()) {
-      window.open(`${PACVIEWER_URL.TESTNET}/transaction/${txHash}`, '_blank');
+      window.open(`${PACTUSSCAN_URL.TESTNET}/transaction/${txHash}`, '_blank');
     } else {
-      window.open(`${PACVIEWER_URL.MAINNET}/transaction/${txHash}`, '_blank');
+      window.open(`${PACTUSSCAN_URL.MAINNET}/transaction/${txHash}`, '_blank');
     }
   };
 
@@ -170,7 +170,7 @@ const SuccessTransferModal: React.FC<SuccessTransferModalProps> = ({
             {t('close')}
           </Button>
           <Button variant="primary" size="medium" onClick={handleViewOnExplorer}>
-            View on Pacviewer
+            View on PactusScan
           </Button>
         </div>
       </div>

--- a/apps/web/src/components/transactions-history/index.tsx
+++ b/apps/web/src/components/transactions-history/index.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useRef } from 'react';
 import { Transaction } from '@/services/transaction';
-import Image from 'next/image';
 import './style.css';
 import Skeleton from '../common/skeleton/Skeleton';
 import { useI18n } from '@/utils/i18n';
 import { formatAmount, formatDate } from '@/utils/format';
 import { Mobile, Tablet } from '../responsive';
+import { PACTUSSCAN_URL } from '@/utils/constants';
 
 interface TransactionsHistoryProps {
   transactions: Transaction[];
@@ -89,48 +89,26 @@ const TransactionsHistory: React.FC<TransactionsHistoryProps> = ({
                         ref={rowIndex === transactions.length - 1 ? lastElementRef : null}
                       >
                         <td className="transactions-history__cell">
-                          {formatDate(transaction.createdAt)}
+                          {formatDate(transaction.blockTime)}
                         </td>
                         <td className="transactions-history__cell transactions-history__cell--hash">
                           <a
-                            href={`https://pacviewer.com/transaction/${transaction.hash}`}
+                            href={`${PACTUSSCAN_URL.MAINNET}/transaction/${transaction.hash}`}
                             target="_blank"
                           >
                             {transaction.hash}
                           </a>
                         </td>
-                        <td className="transactions-history__cell flex" title={transaction.from}>
-                          {transaction.from_address_alias?.icon && (
-                            <Image
-                              src={transaction.from_address_alias.icon}
-                              alt=""
-                              width={16}
-                              height={16}
-                              className="mr-1"
-                            />
-                          )}
-                          <span className="text-truncate">
-                            {transaction.from_address_alias?.title ?? transaction.from}
-                          </span>
+                        <td className="transactions-history__cell flex" title={transaction.sender}>
+                          <span className="text-truncate">{transaction.sender}</span>
                         </td>
-                        <td className="transactions-history__cell" title={transaction.to}>
+                        <td className="transactions-history__cell" title={transaction.receiver}>
                           <div className="flex">
-                            {transaction.to_address_alias?.icon && (
-                              <Image
-                                src={transaction.to_address_alias.icon}
-                                alt=""
-                                width={16}
-                                height={16}
-                                className="mr-1"
-                              />
-                            )}
-                            <span className="text-truncate">
-                              {transaction.to_address_alias?.title ?? transaction.to}
-                            </span>
+                            <span className="text-truncate">{transaction.receiver}</span>
                           </div>
                         </td>
                         <td className="transactions-history__cell">
-                          {formatAmount(transaction.value)}
+                          {formatAmount(transaction.amount)}
                         </td>
                         <td className="transactions-history__cell">
                           {formatAmount(transaction.fee)}
@@ -179,11 +157,11 @@ const TransactionsHistory: React.FC<TransactionsHistoryProps> = ({
             <div key={index} className="w-full flex flex-col gap-2" ref={index === transactions.length - 1 ? lastMobileElementRef : null}>
               <div>
                 <div className="flex justify-between items-center text-xs font-medium">
-                  <div>{formatDate(transaction.createdAt)}</div>
-                  <div>{formatAmount(transaction.value)}</div>
+                  <div>{formatDate(transaction.blockTime)}</div>
+                  <div>{formatAmount(transaction.amount)}</div>
                 </div>
                 <div className="text-sm font-medium text-gradient">
-                  <div>{transaction.from}</div>
+                  <div>{transaction.sender}</div>
                 </div>
               </div>
               {index !== transactions.length - 1 && <div className="h-[1px] bg-gray-200 w-full" />}

--- a/apps/web/src/config/pactusscan.ts
+++ b/apps/web/src/config/pactusscan.ts
@@ -1,0 +1,5 @@
+export const pactusscanConfig = {
+  // TODO: when a separate testnet API host exists, select base per network
+  // (wallet.isTestnet()) instead of using a single mainnet base.
+  url: process.env.NEXT_PUBLIC_PACTUSSCAN_API_URL ?? 'https://api.pactusscan.com',
+};

--- a/apps/web/src/config/pacviewer.ts
+++ b/apps/web/src/config/pacviewer.ts
@@ -1,4 +1,0 @@
-export const pacviwerConfig = {
-    url: process.env.NEXT_PUBLIC_PACVIEWER_API_URL ?? 'https://api.pacviewer.com',
-};
-

--- a/apps/web/src/scenes/wallet/index.tsx
+++ b/apps/web/src/scenes/wallet/index.tsx
@@ -21,7 +21,7 @@ import TransactionsHistory from '@/components/transactions-history';
 import { fetchAccountTransactions, Transaction } from '@/services/transaction';
 import { Mobile, Tablet } from '@/components/responsive';
 import { formatPactusAddress } from '../../utils/common';
-import { PACVIEWER_URL } from '../../utils/constants';
+import { PACTUSSCAN_URL } from '../../utils/constants';
 
 const Wallet = () => {
   const { wallet, setHeaderTitle, setEmoji } = useContext(WalletContext);
@@ -54,9 +54,9 @@ const Wallet = () => {
 
   const handleViewOnExplorer = () => {
     if (wallet?.isTestnet()) {
-      window.open(`${PACVIEWER_URL.TESTNET}/address/${address}`, '_blank');
+      window.open(`${PACTUSSCAN_URL.TESTNET}/address/${address}`, '_blank');
     } else {
-      window.open(`${PACVIEWER_URL.MAINNET}/address/${address}`, '_blank');
+      window.open(`${PACTUSSCAN_URL.MAINNET}/address/${address}`, '_blank');
     }
   };
 
@@ -66,10 +66,8 @@ const Wallet = () => {
     setIsLoadingTransactions(true);
     setHasTransactionError(false);
     try {
-      const response = await fetchAccountTransactions(addressData.address, pageNo);
-      const {
-        data: { data: newTransactions, total_items: totalItems },
-      } = response;
+      const { transactions: newTransactions, total: totalItems } =
+        await fetchAccountTransactions(addressData.address, pageNo);
 
       setTransactions(prev => [...prev, ...newTransactions]);
       setHasMore(transactions.length + newTransactions.length < totalItems);

--- a/apps/web/src/services/transaction.ts
+++ b/apps/web/src/services/transaction.ts
@@ -1,63 +1,75 @@
-import { pacviwerConfig } from '@/config/pacviewer';
+import { pactusscanConfig } from '@/config/pactusscan';
 
 export interface Transaction {
-  id: string;
   hash: string;
   blockHeight: number;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  lock_time: number;
-  version: number;
-  type: number;
-  from: string;
-  to: string;
-  value: number;
-  fee: number;
+  blockTime: number; // unix timestamp in seconds
+  payloadType: number;
+  direction: number;
+  amount: number; // in nanoPAC
+  fee: number; // in nanoPAC
+  sender: string;
+  receiver: string;
   memo: string;
-  signature: string;
-  createdAt: string;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  from_address_alias: AddressAlias | null;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  to_address_alias: AddressAlias | null;
 }
 
-interface AddressAlias {
-  id: string;
-  title: string;
-  description: string;
-  website: string;
-  email: string;
-  type: number;
-  icon: string;
-  addresses: string[] | null;
+export interface AccountTransactions {
+  transactions: Transaction[];
+  total: number;
 }
 
-interface PaginatedResponse<T> {
-  status: number;
-  message: string;
-  data: {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    page_no: number;
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    page_size: number;
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    total_items: number;
-    data: T[];
-  };
+interface RawTransaction {
+  hash: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  block_height: number;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  block_time: number;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  payload_type: number;
+  direction: number;
+  amount: number;
+  fee: number;
+  sender: string;
+  receiver: string;
+  memo: string;
+}
+
+interface AccountTxsResponse {
+  txs: RawTransaction[] | null;
+  total: number;
+  pages: number;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  per_page: number;
 }
 
 export const fetchAccountTransactions = async (
   address: string,
-  pageNo: number = 1,
-  pageSize: number = 20
-): Promise<PaginatedResponse<Transaction>> => {
+  page: number = 1,
+  limit: number = 20
+): Promise<AccountTransactions> => {
   const response = await fetch(
-    `${pacviwerConfig.url}/v1/accounts/${address}/txs?page_no=${pageNo}&page_size=${pageSize}`
+    `${pactusscanConfig.url}/api/v1/account/${address}/txs?page=${page}&limit=${limit}`
   );
 
   if (!response.ok) {
     throw new Error('Failed to fetch transactions');
   }
 
-  return response.json();
+  const result: AccountTxsResponse = await response.json();
+
+  return {
+    transactions: (result.txs ?? []).map(tx => ({
+      hash: tx.hash,
+      blockHeight: tx.block_height,
+      blockTime: tx.block_time,
+      payloadType: tx.payload_type,
+      direction: tx.direction,
+      amount: tx.amount,
+      fee: tx.fee,
+      sender: tx.sender,
+      receiver: tx.receiver,
+      memo: tx.memo,
+    })),
+    total: result.total,
+  };
 };

--- a/apps/web/src/utils/constants.ts
+++ b/apps/web/src/utils/constants.ts
@@ -6,7 +6,7 @@ export const PASSWORD_VALIDATORS = {
   HAS_LOWERCASE: /[a-z]/,
   HAS_NUMBER: /\d/,
 };
-export const PACVIEWER_URL = {
-  MAINNET: 'https://pacviewer.com',
-  TESTNET: 'https://phoenix.pacviewer.com',
+export const PACTUSSCAN_URL = {
+  MAINNET: 'https://pactusscan.com',
+  TESTNET: 'https://phoenix.pactusscan.com',
 };

--- a/apps/web/src/utils/format.ts
+++ b/apps/web/src/utils/format.ts
@@ -4,8 +4,8 @@ export const formatAmount = (value: number): string => {
   return Amount.fromString((value / 1000000000).toString()).format() + ' PAC';
 };
 
-export const formatDate = (dateString: string): string => {
-  const date = new Date(dateString);
+export const formatDate = (timestamp: number): string => {
+  const date = new Date(timestamp * 1000);
   return new Intl.DateTimeFormat('en-US', {
     year: 'numeric',
     month: 'short',


### PR DESCRIPTION
## Description

Migrate the block explorer and transaction data source from Pacviewer to PactusScan.

- Explorer links (address/transaction) now point to PactusScan: mainnet pactusscan.com, testnet phoenix.pactusscan.com.
- Transaction history now consumes the PactusScan API (GET /api/v1/account/:addr/txs) with page/limit paging and its { txs, total } response shape; map snake_case fields to the Transaction model.
- formatDate now takes a unix-seconds timestamp (block_time).
- Drop from/to address aliases: not provided by the txs endpoint; show raw sender/receiver addresses instead.
- Rename config to pactusscanConfig and env var to NEXT_PUBLIC_PACTUSSCAN_API_URL.


