### PR TITLE
fix(web): use testnet pactusscan api on testnet

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,8 @@ module.exports = {
     '^.+\\.tsx?$': 'ts-jest',
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
   testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
 };

--- a/src/components/transactions-history/index.tsx
+++ b/src/components/transactions-history/index.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '@/utils/i18n';
 import { formatAmount, formatDate } from '@/utils/format';
 import { Mobile, Tablet } from '../responsive';
 import { PACTUSSCAN_URL } from '@/utils/constants';
+import { useWallet } from '@/wallet';
 
 interface TransactionsHistoryProps {
   transactions: Transaction[];
@@ -25,6 +26,8 @@ const TransactionsHistory: React.FC<TransactionsHistoryProps> = ({
   hasError = false,
 }) => {
   const { t } = useI18n();
+  const { wallet } = useWallet();
+  const explorerUrl = wallet?.isTestnet() ? PACTUSSCAN_URL.TESTNET : PACTUSSCAN_URL.MAINNET;
   const headings = ['Date', 'TX Hash', 'From', 'To', 'Amount', 'Fee'];
   const observer = useRef<IntersectionObserver | null>(null);
   const lastElementRef = useRef<HTMLTableRowElement | null>(null);
@@ -93,7 +96,7 @@ const TransactionsHistory: React.FC<TransactionsHistoryProps> = ({
                         </td>
                         <td className="transactions-history__cell transactions-history__cell--hash">
                           <a
-                            href={`${PACTUSSCAN_URL.MAINNET}/transaction/${transaction.hash}`}
+                            href={`${explorerUrl}/transaction/${transaction.hash}`}
                             target="_blank"
                           >
                             {transaction.hash}

--- a/src/config/pactusscan.ts
+++ b/src/config/pactusscan.ts
@@ -1,5 +1,4 @@
-export const pactusscanConfig = {
-  // TODO: when a separate testnet API host exists, select base per network
-  // (wallet.isTestnet()) instead of using a single mainnet base.
-  url: process.env.NEXT_PUBLIC_PACTUSSCAN_API_URL ?? 'https://api.pactusscan.com',
+export const PACTUSSCAN_API_URL = {
+  MAINNET: process.env.NEXT_PUBLIC_PACTUSSCAN_API_URL ?? 'https://api.pactusscan.com',
+  TESTNET: process.env.NEXT_PUBLIC_PACTUSSCAN_TESTNET_API_URL ?? 'https://api-testnet.pactusscan.com',
 };

--- a/src/scenes/wallet/index.tsx
+++ b/src/scenes/wallet/index.tsx
@@ -67,7 +67,7 @@ const Wallet = () => {
     setHasTransactionError(false);
     try {
       const { transactions: newTransactions, total: totalItems } =
-        await fetchAccountTransactions(addressData.address, pageNo);
+        await fetchAccountTransactions(addressData.address, pageNo, 20, wallet?.isTestnet() ?? false);
 
       setTransactions(prev => [...prev, ...newTransactions]);
       setHasMore(transactions.length + newTransactions.length < totalItems);
@@ -79,7 +79,7 @@ const Wallet = () => {
     } finally {
       setIsLoadingTransactions(false);
     }
-  }, [addressData?.address, pageNo, hasMore, isLoadingTransactions, transactions.length]);
+  }, [addressData?.address, pageNo, hasMore, isLoadingTransactions, transactions.length, wallet]);
 
   // Reset transactions when address changes
   useEffect(() => {

--- a/src/services/transaction.test.ts
+++ b/src/services/transaction.test.ts
@@ -1,0 +1,42 @@
+import { fetchAccountTransactions } from './transaction';
+import { PACTUSSCAN_API_URL } from '@/config/pactusscan';
+
+describe('fetchAccountTransactions', () => {
+  const emptyResponse = { txs: null, total: 0, pages: 0, per_page: 20 };
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => emptyResponse,
+    } as Response);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('should query the mainnet API by default', async () => {
+    await fetchAccountTransactions('pc1z123');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${PACTUSSCAN_API_URL.MAINNET}/api/v1/account/pc1z123/txs?page=1&limit=20`
+    );
+  });
+
+  it('should query the testnet API when isTestnet is true', async () => {
+    await fetchAccountTransactions('tpc1z123', 2, 10, true);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${PACTUSSCAN_API_URL.TESTNET}/api/v1/account/tpc1z123/txs?page=2&limit=10`
+    );
+  });
+
+  it('should throw when the response is not ok', async () => {
+    fetchSpy.mockResolvedValue({ ok: false } as Response);
+
+    await expect(fetchAccountTransactions('pc1z123')).rejects.toThrow(
+      'Failed to fetch transactions'
+    );
+  });
+});

--- a/src/services/transaction.ts
+++ b/src/services/transaction.ts
@@ -1,4 +1,4 @@
-import { pactusscanConfig } from '@/config/pactusscan';
+import { PACTUSSCAN_API_URL } from '@/config/pactusscan';
 
 export interface Transaction {
   hash: string;
@@ -45,10 +45,13 @@ interface AccountTxsResponse {
 export const fetchAccountTransactions = async (
   address: string,
   page: number = 1,
-  limit: number = 20
+  limit: number = 20,
+  isTestnet: boolean = false
 ): Promise<AccountTransactions> => {
+  const baseUrl = isTestnet ? PACTUSSCAN_API_URL.TESTNET : PACTUSSCAN_API_URL.MAINNET;
+
   const response = await fetch(
-    `${pactusscanConfig.url}/api/v1/account/${address}/txs?page=${page}&limit=${limit}`
+    `${baseUrl}/api/v1/account/${address}/txs?page=${page}&limit=${limit}`
   );
 
   if (!response.ok) {


### PR DESCRIPTION
Closes #299

## Summary

On Testnet, two places still targeted Mainnet PactusScan:

- `fetchAccountTransactions` always queried `api.pactusscan.com`, so testnet accounts showed mainnet transaction history
- The TX hash link in `TransactionsHistory` hardcoded the mainnet explorer

## Changes

- `src/config/pactusscan.ts`: per-network API bases — `api.pactusscan.com` (mainnet) / `api-testnet.pactusscan.com` (testnet), overridable via `NEXT_PUBLIC_PACTUSSCAN_API_URL` / `NEXT_PUBLIC_PACTUSSCAN_TESTNET_API_URL`
- `fetchAccountTransactions` takes `isTestnet` and picks the base; the wallet scene passes `wallet.isTestnet()`
- `TransactionsHistory` follows `wallet.isTestnet()` for the TX link (same pattern as `SuccessTransferModal`)
- Added `moduleNameMapper` for the `@/` alias in `jest.config.js` and tests covering the API base selection

## Depends on

⚠️ Stacked on #298 (single-app npm migration) — marked draft until it merges; the diff will collapse to this fix only afterwards.

## Testing

- `npm test` — 25 tests pass (3 new for the URL selection, failing before the fix)
- `npm run build`, `npm run lint`, `npm run type-check` — clean