### PR TITLE
fix(web): serve wallet-core.wasm from site root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ Thumbs.db
 **/public/locales/*
 **/src/wallet-translation/*
 
+# copied from @trustwallet/wallet-core by scripts/copy-wallet-core-wasm.mjs
+/public/wallet-core.wasm
+
 # lock files
 yarn.lock
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "license": "MIT",
     "private": true,
     "scripts": {
+        "predev": "node scripts/copy-wallet-core-wasm.mjs",
         "dev": "next dev --webpack",
+        "prebuild": "node scripts/copy-wallet-core-wasm.mjs",
         "build": "next build --webpack",
         "start": "next start",
         "lint": "eslint src --ext .js,.jsx,.ts,.tsx",

--- a/scripts/copy-wallet-core-wasm.mjs
+++ b/scripts/copy-wallet-core-wasm.mjs
@@ -1,0 +1,18 @@
+// wallet-core's Emscripten glue resolves wallet-core.wasm relative to
+// document.currentScript, which is unavailable inside webpack chunks, so at
+// runtime it falls back to fetching /wallet-core.wasm from the site root.
+// The build (4.7.0) aborts on Module hooks like locateFile/wasmBinary, so the
+// URL cannot be overridden in code; instead, serve the file at the site root
+// by copying it into public/ before `next dev` / `next build`.
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const source = require.resolve('@trustwallet/wallet-core/dist/lib/wallet-core.wasm');
+const destination = join(dirname(fileURLToPath(import.meta.url)), '..', 'public', 'wallet-core.wasm');
+
+mkdirSync(dirname(destination), { recursive: true });
+copyFileSync(source, destination);
+console.log(`Copied ${source} -> ${destination}`);


### PR DESCRIPTION
## Summary

Fixes wallet initialization failing on https://wallet-beta.pactus.org/ and on local dev with:

```
wasm streaming compile failed: TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok
Aborted(both async and sync fetching of the wasm failed)
```

Closes #301

## Root cause

wallet-core's Emscripten glue resolves the `wallet-core.wasm` URL from `document.currentScript.src`. Inside a webpack-bundled Next.js chunk that value is unavailable when the module executes, so the glue falls back to the page base URL and the browser requests `GET /wallet-core.wasm` from the site root — which returns 404, because `next.config.ts` copies the file to `/_next/static/chunks/` and `/_next/static/chunks/app/` only. Verified in the network tab on both wallet-beta and localhost.

Overriding the URL in code is not possible: the wallet-core 4.7.0 Emscripten build is compiled with a strict incoming-module API and **aborts** if `locateFile`, `wasmBinary`, or `instantiateWasm` is supplied to `initWasm()`.

## Fix

Serve the file at the URL the glue actually requests: a `predev`/`prebuild` script copies `wallet-core.wasm` from `node_modules` into `public/` (gitignored), so it is served at the site root in dev and included in the static export. The copy always stays in sync with the installed package version. The existing CopyPlugin chunk copies are kept as a fallback for environments where `document.currentScript` is available.

## How I tested

- `npm run dev` → `GET /wallet-core.wasm` 200, no console errors, wallet initializes and redirects to `/get-started` (previously aborted with the errors above)
- `npm run build` → `out/wallet-core.wasm` present; served `out/` statically and verified the same in the browser
- `npm run type-check`, `npm run lint`, `npm test` (25/25) all pass