### PR TITLE
chore(deps): bump @pactus/sdk to 0.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.3.0",
             "license": "MIT",
             "dependencies": {
-                "@pactus/sdk": "^0.9.1",
+                "@pactus/sdk": "^0.9.3",
                 "@radix-ui/react-popover": "^1.1.18",
                 "@radix-ui/react-switch": "^1.3.2",
                 "@splinetool/react-spline": "^4.1.0",
@@ -3093,15 +3093,16 @@
             ]
         },
         "node_modules/@pactus/sdk": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/@pactus/sdk/-/sdk-0.9.1.tgz",
-            "integrity": "sha512-bx8Z4erWbHRojrxSfG72WzCXkV+swFRD0dhUVjhLd/VGKLJ4ZnJmnejI3TCf+vqUfSKvEzi3meLYM4H+hG7E1A==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/@pactus/sdk/-/sdk-0.9.3.tgz",
+            "integrity": "sha512-r+zyH0bCDscBL08fqTnodHsYahG4zLeUVCTsuDai59Z61l4zai+9D4sEM2kOrriqtDmwbQFgoS7XpzOhekW4Mw==",
             "license": "MIT",
             "dependencies": {
                 "@trustwallet/wallet-core": "^4.6.15",
                 "argon2-browser": "^1.18.0",
                 "bech32": "^2.0.0",
                 "bip39": "^3.1.0",
+                "blakejs": "^1.2.1",
                 "pactus-jsonrpc": "^1.15.6"
             },
             "engines": {
@@ -6199,6 +6200,12 @@
             "dependencies": {
                 "@noble/hashes": "^1.2.0"
             }
+        },
+        "node_modules/blakejs": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+            "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+            "license": "MIT"
         },
         "node_modules/blurhash": {
             "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "build-storybook": "storybook build"
     },
     "dependencies": {
-        "@pactus/sdk": "^0.9.1",
+        "@pactus/sdk": "^0.9.3",
         "@radix-ui/react-popover": "^1.1.18",
         "@radix-ui/react-switch": "^1.3.2",
         "@splinetool/react-spline": "^4.1.0",


### PR DESCRIPTION
## Summary

Bumps `@pactus/sdk` 0.9.1 → 0.9.3 to pick up the JSON-RPC transport fixes from pactus-project/js-sdk#23 (fixed in js-sdk#24, released as 0.9.3 — 0.9.2 was a broken empty package, see js-sdk#27):

- Requests now go to well-formed `https://<node>/jsonrpc` URLs instead of the malformed `https://<node>/jsonrpc:80`.
- Read-only RPC calls fail over across endpoints when a node is unreachable, fixing the intermittent `net::ERR_CONNECTION_ABORTED` errors observed on wallet-beta (some public nodes are flaky).

## How I tested

- `npm run type-check`, `npm run lint`, `npm test` (25/25) pass with 0.9.3
- `npm run dev` + browser: JSON-RPC preflight/requests hit `https://bootstrap2.pactus.org/jsonrpc` (clean URL, 204/200), no console errors
- Verified the 0.9.3 npm tarball is complete (99 files) and its `dist/wallet/wallet.js` contains the new transport config and `withFailover`