### PR TITLE
feat(mobile): bottom navigation bar and responsive settings pages

### DIFF
--- a/src/app/setting/layout.tsx
+++ b/src/app/setting/layout.tsx
@@ -4,7 +4,7 @@ import SettingSidebar from "@/components/setting-sidebar";
 
 export default function SettingLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex">
+    <div className="setting-layout">
       <SettingSidebar />
       {children}
     </div>

--- a/src/components/bottom-nav/index.tsx
+++ b/src/components/bottom-nav/index.tsx
@@ -1,0 +1,77 @@
+'use client';
+import React from 'react';
+import Image from 'next/image';
+import { usePathname, useRouter } from 'next/navigation';
+import { overviewIcon, sendIcon, receiveIcon, settingsIcon } from '@/assets';
+import { PATHS } from '@/constants/paths';
+import { useI18n } from '@/utils/i18n';
+import SendPac from '../send';
+import ReceivePac from '../receive';
+import './style.css';
+
+const SETTINGS_PATHS: string[] = [
+  PATHS.SETTING_GENERAL,
+  PATHS.WALLET_MANAGER,
+  PATHS.NODE_MANAGER,
+  PATHS.SETTING_ABOUT,
+];
+
+interface TabProps {
+  icon: string;
+  label: string;
+  isActive?: boolean;
+  onClick: () => void;
+}
+
+const Tab: React.FC<TabProps> = ({ icon, label, isActive = false, onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-label={label}
+    aria-current={isActive ? 'page' : undefined}
+    className={`flex flex-1 flex-col items-center justify-center gap-1 py-2 transition-opacity ${
+      isActive ? 'opacity-100' : 'opacity-60 hover:opacity-100'
+    }`}
+  >
+    <Image src={icon} alt="" width={22} height={22} aria-hidden="true" />
+    <span className="text-[10px] font-medium text-quaternary">{label}</span>
+  </button>
+);
+
+// Bottom navigation shown only on mobile (hidden at >=769px, matching the
+// header hamburger breakpoint). Overview/Settings navigate; Send/Receive reuse
+// the existing transaction modals via their custom-trigger prop.
+const BottomNav: React.FC = () => {
+  const pathname = usePathname();
+  const { push } = useRouter();
+  const { t } = useI18n();
+
+  return (
+    <nav
+      className="bottom-nav fixed bottom-0 left-0 right-0 z-40 items-stretch border-t border-surface-light bg-surface-medium"
+      aria-label={t('overview')}
+    >
+      <Tab
+        icon={overviewIcon}
+        label={t('overview')}
+        isActive={pathname === PATHS.HOME}
+        onClick={() => push(PATHS.HOME)}
+      />
+      <SendPac
+        address={''}
+        renderTrigger={open => <Tab icon={sendIcon} label={t('send')} onClick={open} />}
+      />
+      <ReceivePac
+        renderTrigger={open => <Tab icon={receiveIcon} label={t('receive')} onClick={open} />}
+      />
+      <Tab
+        icon={settingsIcon}
+        label={t('settings')}
+        isActive={SETTINGS_PATHS.includes(pathname)}
+        onClick={() => push(PATHS.SETTING_GENERAL)}
+      />
+    </nav>
+  );
+};
+
+export default BottomNav;

--- a/src/components/bottom-nav/style.css
+++ b/src/components/bottom-nav/style.css
@@ -1,0 +1,19 @@
+/* Mobile-only bottom navigation. Display is controlled here (not via Tailwind
+   `flex`/`tablet:hidden`) because a later `.flex` utility wins the cascade over
+   the responsive `hidden` variant and leaks the bar onto desktop. */
+.bottom-nav {
+  display: flex;
+}
+
+/* Hide on tablet and larger, matching the header hamburger breakpoint. */
+@media (min-width: 769px) {
+  .bottom-nav {
+    display: none;
+  }
+}
+
+/* Hide while a modal is open: the modal backdrop is only ~60% opaque, so a
+   fixed bar behind it would otherwise show through and collide with the popup. */
+body:has(.modal-overlay.show) .bottom-nav {
+  display: none;
+}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -2,6 +2,7 @@
 import { Suspense, useState, useEffect, useRef } from 'react';
 import Sidebar from '../sidebar';
 import Header from '../header';
+import BottomNav from '../bottom-nav';
 import { usePathname } from 'next/navigation';
 import { PATHS_WITH_SIDEBAR } from '@/constants/paths';
 import { Toaster } from 'sonner';
@@ -41,10 +42,11 @@ function MainLayout({ children }) {
             isMobile={isMobile}
             hamburgerRef={hamburgerRef}
           />
-          <div className="flex-1 flex flex-col md:ml-[219px]">
+          <div className="flex-1 flex flex-col md:ml-[219px] pb-[64px] tablet:pb-0">
             <Header isSidebarOpen={isSidebarOpen} setIsSidebarOpen={setIsSidebarOpen} hamburgerRef={hamburgerRef} />
             {children}
           </div>
+          <BottomNav />
           <Toaster duration={2500} richColors closeButton position="top-center" />
         </main>
       </Suspense>

--- a/src/components/receive/index.tsx
+++ b/src/components/receive/index.tsx
@@ -12,7 +12,9 @@ import FormSelectInput from '../common/FormSelectInput';
 import { Form, useForm, useWatch } from '../common/Form';
 import { formatPactusAddress } from '@/utils/common';
 
-const ReceivePac: React.FC = () => {
+const ReceivePac: React.FC<{
+  renderTrigger?: (open: () => void) => React.ReactNode;
+}> = ({ renderTrigger }) => {
   const { t } = useI18n();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -34,17 +36,21 @@ const ReceivePac: React.FC = () => {
 
   return (
     <>
-      <Button
-        variant="secondary"
-        size="small"
-        onClick={() => setIsModalOpen(true)}
-        aria-label={t('receive')}
-        startIcon={<Image src={receiveIcon} alt="" width={20} height={20} aria-hidden="true" />}
-        className="w-[119px] h-[38px]"
-        fullWidth
-      >
-        {t('receive')}
-      </Button>
+      {renderTrigger ? (
+        renderTrigger(() => setIsModalOpen(true))
+      ) : (
+        <Button
+          variant="secondary"
+          size="small"
+          onClick={() => setIsModalOpen(true)}
+          aria-label={t('receive')}
+          startIcon={<Image src={receiveIcon} alt="" width={20} height={20} aria-hidden="true" />}
+          className="w-[119px] h-[38px]"
+          fullWidth
+        >
+          {t('receive')}
+        </Button>
+      )}
 
       <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title={t('receive')}>
         <div className="flex flex-col gap-4 p-4">

--- a/src/components/send/index.tsx
+++ b/src/components/send/index.tsx
@@ -3,8 +3,19 @@ import React from 'react';
 
 import TransactionButton from '../transaction/TransactionButton';
 
-const SendPac: React.FC<{ address: string }> = ({ address }) => {
-  return <TransactionButton address={address} type="send" icon={sendIcon} variant="primary" />;
+const SendPac: React.FC<{
+  address: string;
+  renderTrigger?: (open: () => void) => React.ReactNode;
+}> = ({ address, renderTrigger }) => {
+  return (
+    <TransactionButton
+      address={address}
+      type="send"
+      icon={sendIcon}
+      variant="primary"
+      renderTrigger={renderTrigger}
+    />
+  );
 };
 
 export default SendPac;

--- a/src/components/setting-sidebar/SettingSidebar.tsx
+++ b/src/components/setting-sidebar/SettingSidebar.tsx
@@ -3,6 +3,7 @@ import { PATHS } from '@/constants/paths';
 import cn from '@/utils/cn';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
+import './style.css';
 
 interface SidebarItem {
   iconUrl: string;
@@ -39,7 +40,7 @@ const Item: React.FC<ItemProps> = ({ iconUrl, title, isActive = false, onClick }
   <div
     onClick={onClick}
     className={cn(
-      'flex gap-3 w-[170px] rounded-[6px] hover:bg-surface-medium py-1 px-2 cursor-pointer',
+      'setting-nav__item flex items-center gap-3 rounded-[6px] hover:bg-surface-medium py-1 px-2 cursor-pointer',
       { 'bg-surface-medium': isActive }
     )}
   >
@@ -53,7 +54,7 @@ const SettingSidebar: React.FC = () => {
   const { push } = useRouter();
   return (
     <>
-      <div className="flex flex-col gap-2 px-6 py-3 w-[219px] border-r-[1px] border-surface-medium min-h-[calc(100vh-57px)]">
+      <div className="setting-nav">
         {sidebarData.map(({ iconUrl, title, path }) => (
           <Item
             onClick={() => push(path)}

--- a/src/components/setting-sidebar/style.css
+++ b/src/components/setting-sidebar/style.css
@@ -1,0 +1,44 @@
+/* Settings navigation: horizontal tabs on mobile, vertical sidebar on desktop.
+   Uses plain CSS media queries rather than Tailwind `tablet:` variants because
+   the project's utilities.css redefines .flex-row/.flex-col/.hidden without a
+   media query, which overrides the responsive variants and leaks the mobile
+   layout (a row of tabs) onto desktop. */
+.setting-layout {
+  display: flex;
+  flex-direction: column;
+}
+
+.setting-nav {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--color-surface-medium);
+}
+
+.setting-nav__item {
+  width: auto;
+  white-space: nowrap;
+}
+
+@media (min-width: 769px) {
+  .setting-layout {
+    flex-direction: row;
+  }
+
+  .setting-nav {
+    flex-direction: column;
+    width: 219px;
+    padding: 0.75rem 1.5rem;
+    overflow-x: visible;
+    border-bottom: none;
+    border-right: 1px solid var(--color-surface-medium);
+    min-height: calc(100vh - 57px);
+  }
+
+  .setting-nav__item {
+    width: 170px;
+  }
+}

--- a/src/components/transaction/TransactionButton.tsx
+++ b/src/components/transaction/TransactionButton.tsx
@@ -14,6 +14,8 @@ export interface TransactionButtonProps {
   variant?: 'primary' | 'secondary';
   className?: string;
   onClick?: () => void; // For custom actions like external URLs
+  // Render a custom trigger (e.g. a bottom-nav tab) instead of the default button.
+  renderTrigger?: (open: () => void) => React.ReactNode;
 }
 
 const TransactionButton: React.FC<TransactionButtonProps> = ({
@@ -24,6 +26,7 @@ const TransactionButton: React.FC<TransactionButtonProps> = ({
   variant = 'primary',
   className = 'w-[119px] h-[38px]',
   onClick,
+  renderTrigger,
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { t } = useI18n();
@@ -42,17 +45,21 @@ const TransactionButton: React.FC<TransactionButtonProps> = ({
 
   return (
     <>
-      <Button
-        variant={variant}
-        size="small"
-        onClick={handleClick}
-        aria-label={buttonLabel}
-        startIcon={<Image src={icon} alt="" width={20} height={20} aria-hidden="true" />}
-        className={className}
-        fullWidth
-      >
-        {buttonLabel}
-      </Button>
+      {renderTrigger ? (
+        renderTrigger(handleClick)
+      ) : (
+        <Button
+          variant={variant}
+          size="small"
+          onClick={handleClick}
+          aria-label={buttonLabel}
+          startIcon={<Image src={icon} alt="" width={20} height={20} aria-hidden="true" />}
+          className={className}
+          fullWidth
+        >
+          {buttonLabel}
+        </Button>
+      )}
 
       {!onClick && (
         <TransactionModal

--- a/src/scenes/setting/About.tsx
+++ b/src/scenes/setting/About.tsx
@@ -25,7 +25,7 @@ const About: React.FC<AboutProps> = () => {
   const commitDate = process.env.NEXT_PUBLIC_GIT_COMMIT_DATE || '';
 
   return (
-    <div className="flex flex-col flex-1 pl-[52px] pr-[60px] gap-4">
+    <div className="flex flex-col flex-1 px-4 tablet:pl-[52px] tablet:pr-[60px] gap-4">
       <div className="pt-4 space-y-6">
         <div className="space-y-4">
           <Typography variant="body1" color="text-quaternary" className="font-medium">

--- a/src/scenes/setting/General.tsx
+++ b/src/scenes/setting/General.tsx
@@ -29,7 +29,7 @@ const General: React.FC<GeneralProps> = () => {
     },
   ];
   return (
-    <div className="flex flex-col flex-1 pl-[52px] pr-[60px] gap-4">
+    <div className="flex flex-col flex-1 px-4 tablet:pl-[52px] tablet:pr-[60px] gap-4">
       <Form className="pt-4" form={form}>
         <FormSelectInput
           id="language"

--- a/src/scenes/setting/Wallet.tsx
+++ b/src/scenes/setting/Wallet.tsx
@@ -104,7 +104,7 @@ const WalletManager: React.FC<WalletManagerProps> = () => {
 
   return (
     <div className="w-full">
-      <div className="h-[52px] w-full flex justify-end border-b-[1px] border-surface-medium items-center gap-4 pr-4">
+      <div className="min-h-[52px] w-full flex flex-wrap justify-end border-b-[1px] border-surface-medium items-center gap-3 px-4 py-2">
         <div className="text-xs text-[#4C4F6B]">
           <span className="text-text-tertiary">{accountList.length}</span>/ 200
         </div>


### PR DESCRIPTION
## Summary

Makes the wallet feel like a native mobile app and fixes the worst mobile layout offenders.

1. **Mobile bottom navigation bar** (Closes #307): a fixed bar shown only on mobile with Overview · Send · Receive · Settings. Overview/Settings navigate; Send/Receive open the existing transaction modals via a new optional custom-trigger prop on `TransactionButton`/`ReceivePac` (no duplication). Content gets bottom padding so the bar never overlaps it.
2. **Responsive settings pages** (Closes #308): the settings sidebar (General/Wallet Manager/About) was a fixed 219px column beside the content on mobile, squeezing and clipping it. It now renders as a horizontal tab row above full-width content on mobile, and stays a vertical 219px sidebar on desktop. Per-scene content padding is responsive.

## Important implementation note

`src/assets/styles/utilities.css` redefines `.flex`, `.flex-row`, `.flex-col`, `.hidden` **without a media query**, so Tailwind's responsive `tablet:` variants for display/flex-direction are overridden and do not work. Using them leaked the bottom bar onto desktop and rendered the settings tabs horizontally on desktop. All display/flex-direction toggles therefore use dedicated component stylesheets with real media queries (`bottom-nav/style.css`, `setting-sidebar/style.css`). Responsive padding/width/border via Tailwind `tablet:` still work and are used as-is.

## How I tested

- `npm run type-check` and `npm run lint` pass.
- **Mobile** (DevTools device mode): bottom bar shows on Overview/Settings with the right active tab; Send/Receive open their modals; the bar hides while a modal is open. Settings General/Wallet Manager/About render as horizontal tabs with full-width, non-clipped content.
- **Desktop** (1339px): bottom bar is `display:none`; settings sidebar is a vertical 219px column (verified computed styles and visually) — no horizontal tab row.