### PR TITLE
fix(mobile): hide bottom nav while sidebar drawer is open

### DIFF
--- a/src/components/bottom-nav/style.css
+++ b/src/components/bottom-nav/style.css
@@ -17,3 +17,10 @@
 body:has(.modal-overlay.show) .bottom-nav {
   display: none;
 }
+
+/* Hide while the mobile sidebar drawer is open: the drawer already holds the
+   full navigation, and the fixed bar (same stacking level) would otherwise
+   cover the drawer's lower items. */
+body:has(.sidebar.mobile.open) .bottom-nav {
+  display: none;
+}


### PR DESCRIPTION
## Summary

Follow-up to #309. On mobile, the sidebar drawer and the bottom navigation bar share the same stacking level, so the bar covered the drawer''s lower items (Settings, Documentation, FAQs, Report Bug, the Contributing card).

The drawer already contains the full navigation, so this hides the bar while the drawer is open — reusing the same `body:has(...)` pattern that already hides it while a modal is open.

Closes #310

## How I tested

`npm run dev` + DevTools device mode (500px): with the drawer closed the bar is `display:flex`; opening the drawer via the hamburger makes it `display:none`, and the drawer''s lower items are fully visible (verified computed styles + screenshot). Closing the drawer restores the bar.