### PR TITLE
fix(send): keep amount and recipient on the sent success modal

### DIFF
--- a/src/components/transaction/TransactionModal.tsx
+++ b/src/components/transaction/TransactionModal.tsx
@@ -39,6 +39,12 @@ const TransactionModal: React.FC<TransactionModalProps> = ({
   const [countdown, setCountdown] = useState(0);
   const [successMessage] = useState<string | null>(null);
   const [txHash, setTxHash] = useState('');
+  // Snapshot of the sent amount/recipient captured at broadcast time, so the
+  // success modal keeps showing them after formValues is reset for the next tx.
+  const [sentDetails, setSentDetails] = useState<{ amount: string; recipient: string }>({
+    amount: '',
+    recipient: '',
+  });
   const countdownIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [createdDate, setCreatedDate] = useState('');
@@ -90,6 +96,14 @@ const TransactionModal: React.FC<TransactionModalProps> = ({
             .then((broadcastedTxHash) => {
               setTxHash(broadcastedTxHash);
               setCreatedDate(new Date().toLocaleString());
+              // Capture what was sent before clearing the form, so the success
+              // modal can display it (formValues is reset just below).
+              setSentDetails({
+                amount: formValues.amount || '',
+                recipient: isBridgeMode
+                  ? `${wrapToDeposit} (Wrapto Deposit)`
+                  : formValues.receiver || '',
+              });
               setIsPreviewModalOpen(false);
               setIsSending(false);
               setIsSuccessModalOpen(true);
@@ -173,8 +187,8 @@ const TransactionModal: React.FC<TransactionModalProps> = ({
         isOpen={isSuccessModalOpen}
         onClose={() => handleCloseModal(true)}
         txHash={txHash}
-        amount={formValues.amount || ''}
-        recipient={formValues.receiver || ''}
+        amount={sentDetails.amount}
+        recipient={sentDetails.recipient}
         date={createdDate}
       />
     </>


### PR DESCRIPTION
## Summary

After a successful send, the "Sent" modal showed "- PAC" and an empty Recipient even though the transfer went through on-chain.

`handleConfirmTransaction` calls `setFormValues({})` at the same time it opens the success modal, so `SuccessTransferModal` (fed `formValues.amount`/`formValues.receiver`) received empty strings and rendered `-{amount} PAC` -> "- PAC" with a blank recipient.

Fix: snapshot the sent amount and recipient into `sentDetails` at broadcast time, before the form is cleared, and pass that snapshot to the success modal. Bridge mode uses the Wrapto deposit address, matching the preview modal.

Closes #312

## How I tested

- `npm run type-check` and `npm run lint` pass.
- Rendered the success modal with sample data (temporary local edit, reverted): it now shows "-5 PAC" and the recipient address instead of "- PAC"/blank. End-to-end confirmation with a real transfer to follow on beta.