### PR TITLE
chore(release): releasing version 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # CHANGELOG
 
+## [1.3.0](https://github.com/pactus-project/pactus-wallet/compare/v1.2.0...v1.3.0) (2026-07-04)
+
+### Feat
+
+- **settings**: add recovery-phrase viewer and generic explorer icon ([#306](https://github.com/pactus-project/pactus-wallet/pull/306))
+- **mobile**: bottom navigation bar and responsive settings pages ([#309](https://github.com/pactus-project/pactus-wallet/pull/309))
+
+### Fix
+
+- **send**: keep amount and recipient on the sent success modal ([#313](https://github.com/pactus-project/pactus-wallet/pull/313))
+- **mobile**: hide bottom nav while sidebar drawer is open ([#311](https://github.com/pactus-project/pactus-wallet/pull/311))
+- **web**: serve wallet-core.wasm from site root ([#302](https://github.com/pactus-project/pactus-wallet/pull/302))
+- **web**: use testnet pactusscan api on testnet ([#300](https://github.com/pactus-project/pactus-wallet/pull/300))
+
+### Refactor
+
+- **repo**: migrate to single npm app with @pactus/sdk ([#298](https://github.com/pactus-project/pactus-wallet/pull/298))
+- **web**: replace pacviewer with pactusscan ([#296](https://github.com/pactus-project/pactus-wallet/pull/296))
+- **common**: remove unused dead code ([#315](https://github.com/pactus-project/pactus-wallet/pull/315))
+
+### Chore
+
+- **deps**: bump @pactus/sdk to 0.9.3 ([#303](https://github.com/pactus-project/pactus-wallet/pull/303))
+- **repo**: ignore AI agent directories ([#289](https://github.com/pactus-project/pactus-wallet/pull/289))
+
 ## [1.2.0](https://github.com/pactus-project/pactus-wallet/compare/v1.1.0...v1.2.0) (2025-12-20)
 
 ### Feat


### PR DESCRIPTION
Releasing version 1.3.0.

Updates `CHANGELOG.md` with everything merged since v1.2.0 (the monorepo migration to a single npm app with `@pactus/sdk`, plus the wasm-init fix, RPC/PactusScan fixes, mobile UI, and the sent-modal fix).

Per `docs/deployment.md`, after this merges the release is completed by creating and pushing the GPG-signed tag `v1.3.0`, which triggers the production deploy.