### PR TITLE
fix(mobile): truncate addresses, prevent overflow, and fix about version

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,12 +10,26 @@ const argon2WasmPath = require.resolve('argon2-browser/dist/argon2.wasm');
 // Expose the package version to the app (shown on the About page).
 const { version } = require('./package.json');
 
+// Resolve the current git commit (shown on the About page). Falls back to
+// 'unknown' if git is unavailable at build time.
+let gitCommit = 'unknown';
+let gitCommitDate = '';
+try {
+  const { execSync } = require('child_process');
+  gitCommit = execSync('git rev-parse --short HEAD').toString().trim();
+  gitCommitDate = execSync('git log -1 --format=%cd --date=short').toString().trim();
+} catch {
+  // keep defaults
+}
+
 const nextConfig: NextConfig = {
   // Configure the output to be static export
   output: 'export',
 
   env: {
     NEXT_PUBLIC_APP_VERSION: version,
+    NEXT_PUBLIC_GIT_COMMIT: gitCommit,
+    NEXT_PUBLIC_GIT_COMMIT_DATE: gitCommitDate,
   },
 
   images: {

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,9 +7,16 @@ const walletCoreWasmPath = require.resolve('@trustwallet/wallet-core/dist/lib/wa
 // Resolve the path to the argon2.wasm file from the argon2-browser package
 const argon2WasmPath = require.resolve('argon2-browser/dist/argon2.wasm');
 
+// Expose the package version to the app (shown on the About page).
+const { version } = require('./package.json');
+
 const nextConfig: NextConfig = {
   // Configure the output to be static export
   output: 'export',
+
+  env: {
+    NEXT_PUBLIC_APP_VERSION: version,
+  },
 
   images: {
     unoptimized: true, // <-- Add this line to fix the error

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -42,7 +42,7 @@ function MainLayout({ children }) {
             isMobile={isMobile}
             hamburgerRef={hamburgerRef}
           />
-          <div className="flex-1 flex flex-col md:ml-[219px] pb-[64px] tablet:pb-0">
+          <div className="flex-1 min-w-0 flex flex-col md:ml-[219px] pb-[64px] tablet:pb-0">
             <Header isSidebarOpen={isSidebarOpen} setIsSidebarOpen={setIsSidebarOpen} hamburgerRef={hamburgerRef} />
             {children}
           </div>

--- a/src/scenes/setting/Wallet.tsx
+++ b/src/scenes/setting/Wallet.tsx
@@ -12,6 +12,8 @@ import { useRouter } from 'next/navigation';
 import { useContext, useEffect, useState } from 'react';
 import { useI18n } from '../../utils/i18n';
 import AddAccountModal from '../../components/add-account-modal';
+import { Mobile, Tablet } from '@/components/responsive';
+import { truncateAddress } from '@/utils/common';
 
 interface WalletManagerProps {
   title?: string;
@@ -58,14 +60,23 @@ const WalletManager: React.FC<WalletManagerProps> = () => {
       cell: info => {
         const address = info.getValue() as string;
         const query = new URLSearchParams({ address });
+        const goToWallet = () => push(`${PATHS.WALLET}?${query.toString()}`);
+        const className =
+          'text-gradient text-xs font-medium hover:filter hover:brightness-[0.9] cursor-pointer';
 
         return (
-          <span
-            onClick={() => push(`${PATHS.WALLET}?${query.toString()}`)}
-            className="text-gradient text-xs font-medium hover:filter hover:brightness-[0.9] cursor-pointer"
-          >
-            {address}
-          </span>
+          <>
+            <Mobile>
+              <span onClick={goToWallet} className={className} title={address}>
+                {truncateAddress(address)}
+              </span>
+            </Mobile>
+            <Tablet>
+              <span onClick={goToWallet} className={className}>
+                {address}
+              </span>
+            </Tablet>
+          </>
         );
       },
     },

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -19,3 +19,11 @@ export const formatPactusAddress = (address: string): string => {
 
   return `${PACTUS_PREFIX}${cleanAddress}`;
 };
+
+// Middle-truncate a long address for narrow (mobile) layouts, e.g.
+// tpc1r7aq...9k2p3q. Keeps the head and tail so it stays recognizable.
+export const truncateAddress = (address: string, head = 10, tail = 6): string => {
+  if (!address || address.length <= head + tail + 1) return address;
+
+  return `${address.slice(0, head)}...${address.slice(-tail)}`;
+};


### PR DESCRIPTION
## Summary

Fixes three mobile layout issues plus the About version:

1. **Long addresses overflow the wallet-manager table and push the bottom nav off-screen** (Closes #318). Account addresses are long unbreakable strings; on narrow screens they made `/setting/wallet` wider than the viewport, and since the main content flex item had `min-width: auto`, the overflow shifted the whole page and the fixed bottom nav. Now the address is middle-truncated on mobile (e.g. `tpc1rlqv83...gpvsh4`, full value on desktop and in the title), and the main content container gets `min-w-0` so wide content never pushes the page/bottom-nav out of the viewport.
2. **About always showed 1.0.0** (Closes #319). `NEXT_PUBLIC_APP_VERSION` was never set; now exposed from package.json via `next.config.ts` (shows 1.4.0).

The transactions table on the wallet page already uses a card layout on mobile (`<Mobile>`/`<Tablet>`); the `min-w-0` change also protects that page from any residual horizontal overflow.

## How I tested

- `npm run type-check` and `npm run lint` pass.
- About page (dev): now shows **Version: 1.4.0** (was 1.0.0).
- `truncateAddress` verified: `tpc1rlqv83h50wxfr7ddf3rzhplxqng9r9g96gpvsh4` → `tpc1rlqv83...gpvsh4`; short addresses unchanged.
- Visual mobile verification of the truncated table pending on beta (the local dev wallet has no accounts).