### PR TITLE
fix(web): serve wallet-core.wasm for nested /setting routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ Thumbs.db
 
 # copied from @trustwallet/wallet-core by scripts/copy-wallet-core-wasm.mjs
 /public/wallet-core.wasm
+/public/setting/wallet-core.wasm
 
 # lock files
 yarn.lock

--- a/scripts/copy-wallet-core-wasm.mjs
+++ b/scripts/copy-wallet-core-wasm.mjs
@@ -1,8 +1,11 @@
 // wallet-core's Emscripten glue resolves wallet-core.wasm relative to
 // document.currentScript, which is unavailable inside webpack chunks, so at
-// runtime it falls back to fetching /wallet-core.wasm from the site root.
+// runtime it falls back to fetching wallet-core.wasm relative to the current
+// document directory. On a hard load of a nested route the directory is not
+// the site root: e.g. /setting/wallet fetches /setting/wallet-core.wasm.
 // The build (4.7.0) aborts on Module hooks like locateFile/wasmBinary, so the
-// URL cannot be overridden in code; instead, serve the file at the site root
+// URL cannot be overridden in code; instead, serve the file both at the site
+// root (for top-level routes) and under /setting/ (for the /setting/* pages)
 // by copying it into public/ before `next dev` / `next build`.
 import { copyFileSync, mkdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
@@ -11,8 +14,18 @@ import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const source = require.resolve('@trustwallet/wallet-core/dist/lib/wallet-core.wasm');
-const destination = join(dirname(fileURLToPath(import.meta.url)), '..', 'public', 'wallet-core.wasm');
+const publicDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'public');
 
-mkdirSync(dirname(destination), { recursive: true });
-copyFileSync(source, destination);
-console.log(`Copied ${source} -> ${destination}`);
+// Serve the wasm from every directory a hard-loaded route can resolve against.
+// Top-level routes (/, /wallet, /activity, /setting, /get-started, ...) resolve
+// from the site root; the nested settings pages resolve from /setting/.
+const destinations = [
+  join(publicDir, 'wallet-core.wasm'),
+  join(publicDir, 'setting', 'wallet-core.wasm'),
+];
+
+for (const destination of destinations) {
+  mkdirSync(dirname(destination), { recursive: true });
+  copyFileSync(source, destination);
+  console.log(`Copied ${source} -> ${destination}`);
+}


### PR DESCRIPTION
## Summary

Hard-loading or refreshing a nested settings page (`/setting/wallet`, `/setting/node`, `/setting/about`) failed to initialize the wallet: the wasm glue resolves `wallet-core.wasm` relative to the document directory, so at `/setting/wallet` it requested `/setting/wallet-core.wasm` → 404. Navigating back to home worked because there it resolved to the root `/wallet-core.wasm` (added in #302).

Confirmed on beta: `GET https://wallet-beta.pactus.org/setting/wallet-core.wasm 404`.

Fix: the copy script now also writes `public/setting/wallet-core.wasm`, so the nested settings pages resolve the wasm from `/setting/`. Top-level routes keep using the root copy.

Closes #321

## How I tested

- `node scripts/copy-wallet-core-wasm.mjs` writes both `public/wallet-core.wasm` and `public/setting/wallet-core.wasm`.
- Dev: `GET /setting/wallet-core.wasm` → 200; hard-loading `/setting/wallet` fetches `/setting/wallet-core.wasm` (Performance API) with no wasm console errors — previously this 404d.