### PR TITLE
chore(release): releasing version 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [1.4.0](https://github.com/pactus-project/pactus-wallet/compare/v1.3.0...v1.4.0) (2026-07-04)
+
+### Fix
+
+- **web**: serve wallet-core.wasm for nested /setting routes so a hard load of `/setting/*` no longer 404s the wasm ([#322](https://github.com/pactus-project/pactus-wallet/pull/322))
+- **mobile**: truncate long addresses, prevent horizontal overflow (bottom nav no longer pushed off-screen), and show the real app version and commit on the about page ([#320](https://github.com/pactus-project/pactus-wallet/pull/320))
+
 ## [1.3.0](https://github.com/pactus-project/pactus-wallet/compare/v1.2.0...v1.3.0) (2026-07-04)
 
 ### Feat


### PR DESCRIPTION
Releasing version 1.4.0.

Updates `CHANGELOG.md` with the fixes merged since v1.3.0:
- serve wallet-core.wasm for nested `/setting/*` routes (fixes wasm 404 on hard load; also affects production v1.3.0) (#322)
- mobile: truncate long addresses, prevent horizontal overflow, and show the real version/commit on About (#320)

Per `docs/deployment.md`, after this merges the release is completed by pushing the GPG-signed tag `v1.4.0`, which triggers the production deploy.