### PR TITLE
chore(version): bumping version to 1.5.0

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,9 +44,9 @@ Create environment variables for the release version, which will be used in subs
 Keep your terminal open for further steps.
 
 ```bash
-PRV_VER="1.3.0"
-CUR_VER="1.4.0"
-NEXT_VER="1.5.0"
+PRV_VER="1.4.0"
+CUR_VER="1.5.0"
+NEXT_VER="1.6.0"
 BASE_BRANCH="main"
 TAG_NAME="v${CUR_VER}"
 TAG_MSG="Version ${CUR_VER}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pactus-wallet",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "repository": "https://github.com/pactus-project/pactus-wallet.git",
     "license": "MIT",
     "private": true,


### PR DESCRIPTION
Bumping version to 1.5.0 for the next development cycle (docs/deployment.md step 8), following the v1.4.0 production release.