### PR TITLE
fix(bridge): only offer chains Wrapto currently supports

### DIFF
--- a/src/components/send/SendForm.tsx
+++ b/src/components/send/SendForm.tsx
@@ -118,13 +118,19 @@ const SendForm: React.FC<SendFormProps> = ({
   const [internalLoading, setInternalLoading] = useState(false);
 
   const isSubmitting = isLoading || internalLoading;
-  const defaultChain = 'BASE';
-  // Bridge chain options
-  const bridgeChainOptions = [
-    { value: 'BASE', label: 'Base' },
-    { value: 'BSC', label: 'BNB Chain' },
-    { value: 'POLYGON', label: 'Polygon' },
+  const defaultChain = 'BSC';
+  // Bridge chain options. `enabled` reflects what Wrapto currently supports
+  // (https://wrapto.app/). Base and Polygon are temporarily disabled — kept
+  // here (not removed) so they can be re-enabled when Wrapto supports them again.
+  const allBridgeChains = [
+    { value: 'BSC', label: 'BNB Chain', enabled: true },
+    { value: 'ETHEREUM', label: 'Ethereum', enabled: true },
+    { value: 'BASE', label: 'Base', enabled: false },
+    { value: 'POLYGON', label: 'Polygon', enabled: false },
   ];
+  const bridgeChainOptions = allBridgeChains
+    .filter(chain => chain.enabled)
+    .map(({ value, label }) => ({ value, label }));
 
   const transactionTypeOptions = [
     { value: 'TRANSFER', label: 'Transfer' },


### PR DESCRIPTION
## Summary

The bridge chain selector offered **Base, BNB Chain, Polygon** and defaulted to **Base**, but Wrapto (https://wrapto.app/) currently supports only **BNB Chain** and **Ethereum**. Picking Base/Polygon sent PAC to the Wrapto deposit address with a memo Wrapto does not process (risking stuck funds), and Ethereum was not selectable.

Now only **BNB Chain** and **Ethereum** are offered, defaulting to BNB Chain. Base and Polygon are kept in the code, disabled via an `enabled` flag, so they can be re-enabled when Wrapto supports them again. Memo format is unchanged: `<evm-address>@<CHAIN>` (e.g. `…@BSC`, `…@ETHEREUM`).

Closes #327

## How I tested

- `npm run type-check` and `npm run lint` pass.
- Bridge dropdown verification pending on beta (needs a funded wallet to open the bridge modal).