### PR TITLE
feat(settings): add remove wallet action with password confirmation

### DIFF
--- a/src/components/remove-wallet-modal/index.tsx
+++ b/src/components/remove-wallet-modal/index.tsx
@@ -1,0 +1,106 @@
+'use client';
+import React, { useState } from 'react';
+import Modal from '../modal';
+import { useAccount, useWallet } from '@/wallet';
+import { Typography } from '../common/Typography';
+import Button from '../Button';
+import FormPasswordInput from '../common/FormPasswordInput';
+import { useI18n } from '../../utils/i18n';
+import { Form, useForm, useWatch } from '../common/Form';
+
+interface RemoveWalletModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const RemoveWalletModal: React.FC<RemoveWalletModalProps> = ({ isOpen, onClose }) => {
+  const [form] = useForm();
+  const password = useWatch('password', form) || '';
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [passwordTouched, setPasswordTouched] = useState(false);
+  const { getMnemonic } = useAccount();
+  const { removeWallet } = useWallet();
+  const { t } = useI18n();
+
+  // Reset the form whenever the modal closes
+  React.useEffect(() => {
+    if (!isOpen) {
+      form.resetFields();
+      setPasswordTouched(false);
+      setError('');
+      setIsSubmitting(false);
+    }
+  }, [isOpen, form]);
+
+  const handleSubmit = async () => {
+    try {
+      setIsSubmitting(true);
+      setError('');
+      // Verify the password before deleting: getMnemonic throws on a wrong one.
+      await getMnemonic(password);
+      removeWallet();
+      onClose();
+    } catch (err) {
+      setError(`${err}`);
+      setIsSubmitting(false);
+    }
+  };
+
+  const isDisabled = isSubmitting || !password.trim();
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={t('removeWalletTitle')}>
+      <Form
+        className="modal-input-container pl-1 pr-1"
+        form={form}
+        initialValues={{ password: '' }}
+        onFinish={handleSubmit}
+      >
+        <Typography variant="caption1" className="p-1 mb-2 text-orange-400">
+          {t('removeWalletConfirm')}
+        </Typography>
+        <FormPasswordInput
+          id="password"
+          onChange={() => setPasswordTouched(true)}
+          placeholder={t('enterYourPassword')}
+          label={t('password')}
+          hideLabel={true}
+          touched={passwordTouched}
+          error={''}
+        />
+      </Form>
+
+      <div className="flex items-center justify-between gap-3 mt-6 pl-1 pr-1">
+        {error && (
+          <p id="remove-wallet-error" className="modal-error-text" role="alert">
+            {error}
+          </p>
+        )}
+        <div className="flex gap-3 ml-auto">
+          <Button
+            variant="outlined"
+            onClick={onClose}
+            type="button"
+            className="h-[38px]"
+            labelClassName="text-sm"
+          >
+            {t('cancel')}
+          </Button>
+          <Button
+            variant="secondary"
+            disabled={isDisabled}
+            onClick={() => handleSubmit()}
+            type="button"
+            className="h-[38px] bg-red-600 hover:bg-red-700 disabled:opacity-50"
+            labelClassName="text-sm text-white"
+          >
+            {isSubmitting ? 'Removing...' : t('removeWallet')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default RemoveWalletModal;

--- a/src/scenes/setting/Wallet.tsx
+++ b/src/scenes/setting/Wallet.tsx
@@ -3,6 +3,7 @@
 import { plusIcon, trashIcon, showPasswordIcon } from '@/assets';
 import ShowPrivateKeyModal from '@/components/password-modal';
 import ShowRecoveryPhraseModal from '@/components/recovery-phrase-modal';
+import RemoveWalletModal from '@/components/remove-wallet-modal';
 import Table from '@/components/table';
 import { PATHS } from '@/constants/paths';
 import { useAccount, WalletContext } from '@/wallet';
@@ -34,6 +35,7 @@ const WalletManager: React.FC<WalletManagerProps> = () => {
   const { t } = useI18n();
   const [isAddAccountModalOpen, setIsAddAccountModalOpen] = useState(false);
   const [isRecoveryPhraseModalOpen, setIsRecoveryPhraseModalOpen] = useState(false);
+  const [isRemoveWalletModalOpen, setIsRemoveWalletModalOpen] = useState(false);
 
   const closeAddAccountModal = () => {
     setIsAddAccountModalOpen(false);
@@ -147,6 +149,23 @@ const WalletManager: React.FC<WalletManagerProps> = () => {
         <Table columns={columns} data={accountList} />
       </div>
 
+      <section className="mt-8 mx-4 rounded-md border border-red-500/30 bg-red-500/5 p-4">
+        <h3 className="text-sm font-semibold text-red-400 mb-1">⚠ {t('dangerZone')}</h3>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-xs text-text-tertiary max-w-[520px]">
+            {t('removeWalletDescription')}
+          </p>
+          <button
+            type="button"
+            onClick={() => setIsRemoveWalletModalOpen(true)}
+            className="text-xs font-medium text-white h-8 px-3 rounded-sm bg-red-600 hover:bg-red-700 flex items-center gap-2 cursor-pointer whitespace-nowrap"
+          >
+            <Image src={trashIcon} width={14} height={14} alt="" aria-hidden="true" />
+            {t('removeWallet')}
+          </button>
+        </div>
+      </section>
+
       <ShowPrivateKeyModal
         isOpen={Boolean(privateKeyAddress)}
         onClose={() => setPrivateKeyAddress('')}
@@ -156,6 +175,10 @@ const WalletManager: React.FC<WalletManagerProps> = () => {
       <ShowRecoveryPhraseModal
         isOpen={isRecoveryPhraseModalOpen}
         onClose={() => setIsRecoveryPhraseModalOpen(false)}
+      />
+      <RemoveWalletModal
+        isOpen={isRemoveWalletModalOpen}
+        onClose={() => setIsRemoveWalletModalOpen(false)}
       />
     </div>
   );

--- a/src/utils/i18n/translations/en.ts
+++ b/src/utils/i18n/translations/en.ts
@@ -175,6 +175,13 @@ const translations = {
   confirmLogout: 'Logout',
   logoutWarning:
     'Are you sure you want to sign out? This action will remove your wallet from this device. You will need your recovery phrase to recover your wallet.',
+  dangerZone: 'Danger zone',
+  removeWallet: 'Remove wallet',
+  removeWalletDescription:
+    'Removing this wallet deletes it from this browser. Back up your recovery phrase first. Without it, your funds are lost forever.',
+  removeWalletTitle: 'Remove wallet?',
+  removeWalletConfirm:
+    'This permanently deletes the wallet from this browser and cannot be undone. Enter your password to confirm.',
   updatePassword: 'Update Wallet Password',
   oldPassword: 'Old Password',
   newPassword: 'New Password',

--- a/src/wallet/provider/index.tsx
+++ b/src/wallet/provider/index.tsx
@@ -38,6 +38,9 @@ export const WalletContext = createContext<WalletContextType>({
   setWalletName: () => {
     /* Will be implemented in provider */
   },
+  removeWallet: () => {
+    /* Will be implemented in provider */
+  },
   walletManager: null,
   isInitializingManager: true,
   managerError: null,
@@ -156,6 +159,24 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     console.warn('Network type is determined by IS_PRODUCTION environment variable and cannot be changed at runtime');
   };
 
+  // Permanently remove the current wallet from this browser and reset all
+  // in-memory state, then send the user back to onboarding to create/restore
+  // a new one. Destructive: the caller is responsible for confirming intent
+  // (e.g. password re-entry) before invoking this.
+  const removeWallet = () => {
+    if (wallet && walletManager) {
+      walletManager.deleteWallet(wallet.getID());
+    }
+    localStorage.removeItem('walletStatus');
+    setWallet(null);
+    setWalletStatusState(WalletStatus.WALLET_LOCKED);
+    setPasswordState('');
+    setMnemonicState('');
+    setWalletNameState('');
+    setAccountListState([]);
+    router.replace(PATHS.GET_START);
+  };
+
   // Update wallet status and handle navigation
   const setWalletStatus = (value: WalletStatus) => {
     localStorage.setItem('walletStatus', value);
@@ -206,6 +227,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         setNetworkType, // Use the new wrapper function
         walletName,
         setWalletName: setWalletNameState,
+        removeWallet,
         walletManager,
         isInitializingManager,
         managerError,

--- a/src/wallet/types/index.ts
+++ b/src/wallet/types/index.ts
@@ -20,6 +20,7 @@ export interface WalletContextType {
   setNetworkType: () => void; // Network type is determined by IS_PRODUCTION env var only
   walletName: string;
   setWalletName: React.Dispatch<React.SetStateAction<string>>;
+  removeWallet: () => void;
   walletManager: WalletManager | null;
   isInitializingManager: boolean;
   managerError: string | null;


### PR DESCRIPTION
Closes #331

## What
Adds a "Remove wallet" action under Settings > Wallet, in a marked danger zone, so users can exit the current wallet and start a new one without clearing browser storage manually.

## How
- New `removeWallet()` on the wallet provider: deletes the wallet via `WalletManager.deleteWallet(id)`, clears in-memory state and the stored wallet status, then redirects to onboarding.
- New confirmation modal that requires the password (verified through `getMnemonic`, which throws on a wrong one) before deleting.
- Danger zone section in Settings > Wallet with a red "Remove wallet" button.

## Testing
- Local dev (testnet build). Wrong password shows an error and keeps the wallet; correct password removes it and redirects to /get-started, after which a fresh wallet can be created.
- type-check, lint, and the existing jest suite (25 tests) pass.