### PR TITLE
fix(settings): separate language and security in general settings

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -71,7 +71,7 @@ export const Button = ({
     primary: 'bg-gradient-primary text-white hover:opacity-90 disabled:opacity-50',
     secondary: 'bg-background text-white hover:opacity-85 disabled:opacity-50',
     outlined:
-      'border border-gray-300 bg-transparent text-text-primary hover:bg-gray-50 disabled:text-gray-300',
+      'border border-surface-medium bg-transparent text-text-primary hover:bg-surface-medium disabled:opacity-50',
     text: 'bg-transparent text-text-primary hover:bg-gray-100 disabled:text-gray-300',
   };
 

--- a/src/components/change-password-modal/ChangePasswordModal.tsx
+++ b/src/components/change-password-modal/ChangePasswordModal.tsx
@@ -9,7 +9,12 @@ import { validatePassword } from '@/utils/password-validator';
 import { useAccount } from '@/wallet';
 import { toast } from 'sonner';
 
-const ChangePasswordModal: React.FC = () => {
+interface ChangePasswordModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({ isOpen, onClose }) => {
   const { t } = useI18n();
   const { changePassword } = useAccount();
   const [form] = useForm();
@@ -17,7 +22,6 @@ const ChangePasswordModal: React.FC = () => {
   const [newPasswordError, setNewPasswordError] = useState('');
   const [newPasswordTouched, setNewPasswordTouched] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
 
   const handleNewPasswordChange = e => {
     setNewPasswordTouched(true);
@@ -39,7 +43,7 @@ const ChangePasswordModal: React.FC = () => {
 
       if (result) {
         toast.success('Update wallet password successfully!');
-        setIsOpen(false);
+        onClose();
         form.resetFields();
       }
     } catch (err) {
@@ -51,17 +55,7 @@ const ChangePasswordModal: React.FC = () => {
   };
 
   return (
-    <>
-      <Button
-        variant="primary"
-        size="small"
-        onClick={() => setIsOpen(true)}
-        className="w-[150px] h-[38px]"
-        labelClassName="text-sm"
-      >
-        Update Password
-      </Button>
-      <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} title={t('updatePassword')}>
+    <Modal isOpen={isOpen} onClose={onClose} title={t('updatePassword')}>
         <Form
           className="flex flex-col gap-5"
           onFinish={handleSubmit}
@@ -119,8 +113,7 @@ const ChangePasswordModal: React.FC = () => {
             {isSubmitting ? 'Creating...' : 'Create'}
           </Button>
         </Form>
-      </Modal>
-    </>
+    </Modal>
   );
 };
 

--- a/src/scenes/setting/General.tsx
+++ b/src/scenes/setting/General.tsx
@@ -1,9 +1,10 @@
 'use client';
 import { WalletContext } from '@/wallet';
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import FormSelectInput from '../../components/common/FormSelectInput';
 import { useI18n } from '../../utils/i18n';
 import { Form, useForm } from '@/components/common/Form';
+import Button from '@/components/Button';
 import ChangePasswordModal from '@/components/change-password-modal';
 
 interface GeneralProps {
@@ -13,12 +14,14 @@ interface GeneralProps {
 const General: React.FC<GeneralProps> = () => {
   const [form] = useForm();
   const { setHeaderTitle, setEmoji } = useContext(WalletContext);
+  const { t } = useI18n();
+  const [isChangePasswordOpen, setIsChangePasswordOpen] = useState(false);
 
   useEffect(() => {
     setHeaderTitle(t('settingsGeneral'));
     setEmoji('');
   }, []);
-  const { t } = useI18n();
+
   const defaultLanguage = t('englishUs');
 
   // Prepare account options for selects
@@ -28,18 +31,50 @@ const General: React.FC<GeneralProps> = () => {
       label: defaultLanguage,
     },
   ];
+
   return (
-    <div className="flex flex-col flex-1 px-4 tablet:pl-[52px] tablet:pr-[60px] gap-4">
-      <Form className="pt-4" form={form}>
-        <FormSelectInput
-          id="language"
-          name="language"
-          options={accountOptions}
-          label={t('language')}
-          className="w-full text-sm text-quaternary"
-        />
-      </Form>
-      <ChangePasswordModal />
+    <div className="flex flex-col flex-1 px-4 tablet:pl-[52px] tablet:pr-[60px] gap-6 pt-4">
+      {/* Language */}
+      <section className="flex flex-col gap-2">
+        <h3 className="text-sm font-semibold text-text-primary">{t('language')}</h3>
+        <Form form={form}>
+          <FormSelectInput
+            id="language"
+            name="language"
+            options={accountOptions}
+            label={t('language')}
+            hideLabel={true}
+            className="w-full text-sm text-quaternary"
+          />
+        </Form>
+      </section>
+
+      <hr className="border-surface-medium" />
+
+      {/* Security */}
+      <section className="flex flex-col gap-3">
+        <h3 className="text-sm font-semibold text-text-primary">{t('security')}</h3>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-col">
+            <span className="text-sm text-text-primary">{t('password')}</span>
+            <span className="text-xs text-text-tertiary tracking-[0.2em]">••••••••</span>
+          </div>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => setIsChangePasswordOpen(true)}
+            className="h-[38px]"
+            labelClassName="text-sm"
+          >
+            {t('changePassword')}
+          </Button>
+        </div>
+      </section>
+
+      <ChangePasswordModal
+        isOpen={isChangePasswordOpen}
+        onClose={() => setIsChangePasswordOpen(false)}
+      />
     </div>
   );
 };

--- a/src/utils/i18n/translations/en.ts
+++ b/src/utils/i18n/translations/en.ts
@@ -176,6 +176,7 @@ const translations = {
   logoutWarning:
     'Are you sure you want to sign out? This action will remove your wallet from this device. You will need your recovery phrase to recover your wallet.',
   updatePassword: 'Update Wallet Password',
+  changePassword: 'Change password',
   oldPassword: 'Old Password',
   newPassword: 'New Password',
   bondTransaction: 'Bond Transaction',


### PR DESCRIPTION
Closes #332

## What
Reworks Settings > General so the password action no longer reads as a "save Language" button.

## How
- Split the page into labeled "Language" and "Security" sections separated by a divider.
- The password control is now an outlined "Change password" button instead of the primary gradient one.
- `ChangePasswordModal` is now controlled via `isOpen`/`onClose` props (its internal trigger button was removed).
- Fixed the `outlined` Button variant, whose near white hover background hid the label on the dark theme; it now uses the dark surface tokens.
- Minor: moved the `t` binding above the effect that uses it in General.

## Testing
- Local dev: the two sections are clearly separated, the button no longer looks like a form save button, and its label stays visible on hover. Change password modal still opens and works.
- type-check, lint, and the existing jest suite (25 tests) pass.